### PR TITLE
DynamoDBへblueflake ID登録処理を実装

### DIFF
--- a/lib/blueflake-stack.ts
+++ b/lib/blueflake-stack.ts
@@ -13,8 +13,8 @@ export class BlueflakeStack extends cdk.Stack {
     // DynamoDB設定
     const sequenceTable = new Table(this, "sequenceTable", {
       partitionKey: {
-        name: "timestamp",
-        type: AttributeType.NUMBER,
+        name: "timeStampAndRandomKey",
+        type: AttributeType.STRING,
       },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     })

--- a/lib/dynamodb/db.ts
+++ b/lib/dynamodb/db.ts
@@ -1,0 +1,50 @@
+import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand } from "@aws-sdk/client-dynamodb"
+
+const dynamoDbClient = new DynamoDBClient({})
+
+export async function getItem(tableName:string, timeStampAndRandomKey:string) {
+    const command = new GetItemCommand({
+        TableName: tableName,
+        Key: {
+            timeStampAndRandomKey:  {S: timeStampAndRandomKey}
+        }
+    })
+    return await dynamoDbClient.send(command)
+}
+
+export async function registItem(tableName:string, timeStampAndRandomKey:string, sequenceNumber:number) {
+    const command = new PutItemCommand({
+        TableName: tableName,
+        Item: {
+            timeStampAndRandomKey:  {
+                S: timeStampAndRandomKey
+            },
+            sequenceNumber: {
+                N: sequenceNumber.toString()
+            }
+        }
+    })
+    return await dynamoDbClient.send(command)
+}
+
+export async function updateItem(tableName:string, timeStampAndRandomKey:string, oldSequenceNumber:number, nextSequenceNumber:number) {
+    const command = new UpdateItemCommand({
+        TableName: tableName,
+        Key: {
+            timeStampAndRandomKey:  {
+                S: timeStampAndRandomKey
+            },
+        },
+        UpdateExpression: "set sequenceNumber = :nextNumber",
+        ConditionExpression: "sequenceNumber = :oldNumber",
+        ExpressionAttributeValues: {
+            ":nextNumber": {
+                N: nextSequenceNumber.toString()
+            },
+            ":oldNumber": {
+                N: oldSequenceNumber.toString()
+            }
+        },
+    })
+    return await dynamoDbClient.send(command)
+}

--- a/lib/lambda/api/v1-sequence.ts
+++ b/lib/lambda/api/v1-sequence.ts
@@ -1,16 +1,47 @@
-import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb"
+import { DynamoDBClient, GetItemCommand, PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb"
+import { getNowDate, getRandomKey, makeBlueFlakeID } from "../../common/generate-id"
 
 
 const dynamoDbClient = new DynamoDBClient({})
 
-const timestampItems = async (tableName:string) => {
-    const command = new ScanCommand({
+async function getItem(tableName:string, timeStampAndRandomKey:string) {
+    const command = new GetItemCommand({
         TableName: tableName,
+        Key: {
+            timeStampAndRandomKey:  {S: timeStampAndRandomKey}
+        }
     })
-    return (await dynamoDbClient.send(command)).Items
+    return await dynamoDbClient.send(command)
+}
+
+async function registItem(tableName:string, timeStampAndRandomKey:string, sequenceNumber:number) {
+    const command = new PutItemCommand({
+        TableName: tableName,
+        Item: {
+            timeStampAndRandomKey:  {
+                S: timeStampAndRandomKey
+            },
+            sequenceNumber: {
+                N: sequenceNumber.toString()
+            }
+        }
+    })
+    return await dynamoDbClient.send(command)
 }
 
 export const handler = async () => {
     const tableName = process.env.SEQUENCE_TABLE_NAME!
-    return await timestampItems(tableName)
+    const nowDate =  getNowDate();
+    // timestamp + randomkey(ex.0001)をパーティションキーとしている
+    const randomKey = getRandomKey()
+    const timeStampAndRandomKey = nowDate.getTime().toString() + randomKey.toString().padStart(4, "0")
+    const item = await getItem(tableName, timeStampAndRandomKey)
+    const sequenceNumber = item?.Item?.sequenceNumber;
+    if (sequenceNumber === undefined) {
+        // 新規登録
+        registItem(tableName, timeStampAndRandomKey, 1)
+        return makeBlueFlakeID(nowDate, randomKey, 1)
+    }
+
+    return 0
 }


### PR DESCRIPTION
blueflake IDをDynamoDBに見に行ってから登録、生成する処理の実装PRです。
ここまででcurlで新規ID採番まではできるようになりました。
~~シーケンス番号衝突時のカウントアップ処理とエラー処理はまだです。~~
→ 実装しました。

#### 例
curlで生成されたblueflake IDは以下のようになります。

```
$ curl https://*****.cloudfront.net/v1/sequence
> 1199852995895297
$ curl https://*****.cloudfront.net/v1/sequence
> 1199869324865537
$ curl https://*****.cloudfront.net/v1/sequence
> 1200971387056129
$ curl https://*****.cloudfront.net/v1/sequence
> 1201207026982913
$ curl https://*****.cloudfront.net/v1/sequence
> 1201402746630145
```
また、DB側で管理しているシーケンス番号は以下のようになります。
<img width="539" alt="db例" src="https://github.com/hasegawa/blueflake/assets/50223611/7d5e8325-823d-4e02-a38a-5cb218142520">
